### PR TITLE
Defensive egress filter for subscribe_entities events

### DIFF
--- a/websocket-stripper/CHANGELOG.md
+++ b/websocket-stripper/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.0.2 — 2026-06-19
+
+- Defensive egress filter: in addition to injecting `entity_ids` (so HA streams only
+  the allowlist) and trimming the `get_states` result, the proxy now re-filters the
+  `subscribe_entities` event payloads (`a`/`c`/`r`) to the allowlist on the way out.
+  Normally a no-op, but it guarantees the full entity firehose can never reach the
+  browser even if a future HA ignored the `entity_ids` subscription filter.
+
 ## 0.0.1 — 2026-06-19
 
 Initial public release.

--- a/websocket-stripper/config.yaml
+++ b/websocket-stripper/config.yaml
@@ -1,5 +1,5 @@
 name: WebSocket Stripper
-version: "0.0.1"
+version: "0.0.2"
 slug: websocket_stripper
 stage: stable
 description: Serves your real HA dashboards but trims the entity websocket to only what each dashboard uses — fast kiosk loads, full fidelity.

--- a/websocket-stripper/ha_ws_trim_proxy.mjs
+++ b/websocket-stripper/ha_ws_trim_proxy.mjs
@@ -153,6 +153,7 @@ server.on('upgrade', (req, socket, head) => {
 function bridge(browserWs) {
   const haWs = new WebSocket(HA_WS, { perMessageDeflate: true, maxPayload: 0 });
   const getStatesIds = new Set();
+  const subEntityIds = new Set();   // subscribe_entities subs we injected the allowlist into
   const queue = []; let haOpen = false;
   const toHA = (s) => { if (haOpen) haWs.send(s); else queue.push(s); };
 
@@ -164,8 +165,10 @@ function bridge(browserWs) {
     if (STRIP && m && m.type === 'get_states') getStatesIds.add(m.id);
     if (STRIP && m && m.type === 'subscribe_entities' && !m.entity_ids) {
       m.entity_ids = [...ALLOW];           // HA now streams only the allowlist
+      subEntityIds.add(m.id);              // remember it, to defensively re-filter its events
       s = JSON.stringify(m);
     }
+    if (m && m.type === 'unsubscribe_events' && m.subscription != null) subEntityIds.delete(m.subscription);
     toHA(s);
   });
 
@@ -178,6 +181,25 @@ function bridge(browserWs) {
       getStatesIds.delete(m.id);
       s = JSON.stringify(m);
       log(`get_states trimmed ${before} -> ${m.result.length}`);
+    }
+    // Defensive egress filter (belt-and-suspenders): HA already trims to the injected
+    // entity_ids, so this is normally a no-op. But if a future HA ever ignored that
+    // filter, re-filter the subscribe_entities event payload to the allowlist here so
+    // the full firehose can never leak to the browser. Compressed format: a=added,
+    // c=changed (both dicts keyed by entity_id), r=removed (list of entity_ids).
+    if (STRIP && m && m.type === 'event' && subEntityIds.has(m.id) && m.event) {
+      const ev = m.event; let changed = false;
+      for (const k of ['a', 'c']) {
+        if (ev[k]) for (const eid of Object.keys(ev[k])) {
+          if (!ALLOW.has(eid)) { delete ev[k][eid]; changed = true; }
+        }
+      }
+      if (Array.isArray(ev.r)) {
+        const before = ev.r.length;
+        ev.r = ev.r.filter((eid) => ALLOW.has(eid));
+        if (ev.r.length !== before) changed = true;
+      }
+      if (changed) s = JSON.stringify(m);
     }
     safeSend(s);
   });


### PR DESCRIPTION
## What
Adds a defensive **egress** filter to the websocket bridge. Events for the `subscribe_entities` subscriptions we trim are re-filtered to the allowlist on the way back to the browser, in addition to the existing source-side trim.

## Why
Today we inject `entity_ids` into `subscribe_entities` (so HA streams only the allowlist) and filter the `get_states` result. Both rely on HA honoring the `entity_ids` subscription filter. If a future HA version ever changed or ignored that behavior, the full entity firehose would silently leak to the browser again. This adds a second, independent layer so that can never happen.

## How
- Track the subscription ids where we injected the allowlist (`subEntityIds`), cleaned up on `unsubscribe_events`.
- For `event` messages on those subscriptions, filter the compressed payload to the allowlist: `a` (added) and `c` (changed) dicts keyed by entity_id, and `r` (removed) list.
- Only re-serialize when something was actually dropped (normally a no-op, ~zero overhead).

## Scope / safety
- Scoped to subscriptions **we** trimmed — browser-specified `entity_ids` subscriptions are untouched.
- Does not blanket-drop `state_changed` (which could break logbook / other event consumers); it targets only the `subscribe_entities` path we already control.
- Version bumped to 0.0.2; CHANGELOG updated.

## Credit
Idea adapted from [DragonHunter274/homeassistant-entity-filter-proxy](https://github.com/DragonHunter274/homeassistant-entity-filter-proxy), which drops outbound `state_changed` events as a similar safeguard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)