### PR TITLE
Group expansion: require the member to exist

### DIFF
--- a/websocket-stripper/lovelace_extract.mjs
+++ b/websocket-stripper/lovelace_extract.mjs
@@ -216,6 +216,18 @@ export function collectTemplates(config) {
 // only the group entity in the config; the members live in the group's `entity_id` attribute
 // at runtime and appear nowhere in the dashboard (issue #4). Pull them in transitively so a
 // group on the allowlist brings its members with it. Bounded in case a group cycles.
+//
+// A member must actually EXIST. `isEntityId` is only a shape test, and a group's member list
+// can outlive its members — an entity is renamed or removed and nothing rewrites the lists that
+// point at it. Those ids then enter the allowlist, match nothing, and inflate every count the
+// proxy reports. Measured on one instance: 87 light groups listing 409 dead members put 239
+// phantom ids into a 772-entity allowlist — 31% of it. Harmless to forward (an entry matching
+// no entity forwards nothing), but it makes `allowlist: N entities` wrong by a third, and that
+// is the number people tune the `dashboards` option against.
+//
+// Every other path into the allowlist is already gated on the id being real: the config-text
+// scrape in ha_ws_trim_proxy.mjs checks `real.has()`, and the rendered-template scrape below
+// checks `ctx.byId.has()`. This was the one that was not.
 export function expandGroupMembers(ids, allStates = [], maxDepth = 5) {
   const byId = new Map(allStates.map((s) => [s.entity_id, s]));
   const out = new Set(ids);
@@ -225,7 +237,7 @@ export function expandGroupMembers(ids, allStates = [], maxDepth = 5) {
     for (const id of frontier) {
       const members = byId.get(id)?.attributes?.entity_id;
       if (!Array.isArray(members)) continue;
-      for (const e of members) if (isEntityId(e) && !out.has(e)) { out.add(e); next.push(e); }
+      for (const e of members) if (isEntityId(e) && byId.has(e) && !out.has(e)) { out.add(e); next.push(e); }
     }
     frontier = next;
   }

--- a/websocket-stripper/lovelace_extract.mjs
+++ b/websocket-stripper/lovelace_extract.mjs
@@ -217,13 +217,19 @@ export function collectTemplates(config) {
 // at runtime and appear nowhere in the dashboard (issue #4). Pull them in transitively so a
 // group on the allowlist brings its members with it. Bounded in case a group cycles.
 //
-// A member must actually EXIST. `isEntityId` is only a shape test, and a group's member list
-// can outlive its members — an entity is renamed or removed and nothing rewrites the lists that
-// point at it. Those ids then enter the allowlist, match nothing, and inflate every count the
-// proxy reports. Measured on one instance: 87 light groups listing 409 dead members put 239
-// phantom ids into a 772-entity allowlist — 31% of it. Harmless to forward (an entry matching
-// no entity forwards nothing), but it makes `allowlist: N entities` wrong by a third, and that
-// is the number people tune the `dashboards` option against.
+// A member must be IN THE STATE MACHINE. `isEntityId` is only a shape test, and a group's
+// `entity_id` attribute lists members by id whether or not HA is currently serving them — most
+// often because the member is DISABLED, and also if it has been removed or renamed. A disabled
+// entity is a perfectly valid registry entry; it simply has no state, so HA will never stream
+// it and allowlisting it can only ever be dead weight.
+//
+// Measured on one instance: 87 Hue room/zone groups listed 409 member ids that `get_states`
+// does not return, putting 239 of them into a 772-entity allowlist — 31% of it. Checked rather
+// than assumed: all 239 were present in the entity registry and all were disabled
+// (`disabled_by: device`, the devices disabled by the user) — deliberate curation to control
+// entity count, not stale data. Harmless to forward (an entry matching no entity forwards
+// nothing), but it makes `allowlist: N entities` wrong by a third, and that is the number
+// people tune the `dashboards` option against.
 //
 // Every other path into the allowlist is already gated on the id being real: the config-text
 // scrape in ha_ws_trim_proxy.mjs checks `real.has()`, and the rendered-template scrape below

--- a/websocket-stripper/test/extract.filters.test.mjs
+++ b/websocket-stripper/test/extract.filters.test.mjs
@@ -142,20 +142,21 @@ describe('group membership expansion (issue #4)', () => {
       ['group.a', 'group.b', 'light.kitchen']);
   });
 
-  // A group's member list can outlive its members: an entity is renamed or removed and
-  // nothing rewrites the lists pointing at it. `isEntityId` is only a shape test, so those
-  // ids used to enter the allowlist and inflate every count the proxy reports.
-  test('a member that no longer exists is not forwarded', () => {
+  // A group's `entity_id` attribute lists members whether or not HA is serving them — most
+  // often because the member is DISABLED (a valid registry entry with no state), and also if
+  // it was removed or renamed. `isEntityId` is only a shape test, so those ids used to enter
+  // the allowlist and inflate every count the proxy reports.
+  test('a member with no state is not forwarded', () => {
     const stale = [
       { entity_id: 'light.hallway', state: 'off', attributes: { entity_id: ['light.hallway_1', 'light.hallway_2'] } },
       { entity_id: 'light.hallway_1', state: 'off', attributes: {} },
-      // light.hallway_2 was renamed away; the group's list still names it
+      // light.hallway_2 has no state (disabled, or removed); the group still names it
     ];
     assert.deepEqual([...expandGroupMembers(['light.hallway'], stale)].sort(),
       ['light.hallway', 'light.hallway_1']);
   });
 
-  test('a group whose whole member list is dead contributes nothing', () => {
+  test('a group whose members all lack state contributes nothing', () => {
     const allDead = [
       { entity_id: 'light.dining', state: 'on', attributes: { entity_id: ['light.dining_1', 'light.dining_2'] } },
     ];
@@ -164,7 +165,7 @@ describe('group membership expansion (issue #4)', () => {
 
   // Transitive expansion must not be stopped by a dead id in the middle of a chain: the
   // live members below it are still needed.
-  test('a dead member does not break expansion of its live siblings', () => {
+  test('a stateless member does not break expansion of its live siblings', () => {
     const mixed = [
       { entity_id: 'group.top', state: 'on', attributes: { entity_id: ['light.gone', 'group.inner'] } },
       { entity_id: 'group.inner', state: 'on', attributes: { entity_id: ['light.kitchen'] } },

--- a/websocket-stripper/test/extract.filters.test.mjs
+++ b/websocket-stripper/test/extract.filters.test.mjs
@@ -141,4 +141,36 @@ describe('group membership expansion (issue #4)', () => {
     assert.deepEqual([...expandGroupMembers(['group.a'], cyclic)].sort(),
       ['group.a', 'group.b', 'light.kitchen']);
   });
+
+  // A group's member list can outlive its members: an entity is renamed or removed and
+  // nothing rewrites the lists pointing at it. `isEntityId` is only a shape test, so those
+  // ids used to enter the allowlist and inflate every count the proxy reports.
+  test('a member that no longer exists is not forwarded', () => {
+    const stale = [
+      { entity_id: 'light.hallway', state: 'off', attributes: { entity_id: ['light.hallway_1', 'light.hallway_2'] } },
+      { entity_id: 'light.hallway_1', state: 'off', attributes: {} },
+      // light.hallway_2 was renamed away; the group's list still names it
+    ];
+    assert.deepEqual([...expandGroupMembers(['light.hallway'], stale)].sort(),
+      ['light.hallway', 'light.hallway_1']);
+  });
+
+  test('a group whose whole member list is dead contributes nothing', () => {
+    const allDead = [
+      { entity_id: 'light.dining', state: 'on', attributes: { entity_id: ['light.dining_1', 'light.dining_2'] } },
+    ];
+    assert.deepEqual([...expandGroupMembers(['light.dining'], allDead)], ['light.dining']);
+  });
+
+  // Transitive expansion must not be stopped by a dead id in the middle of a chain: the
+  // live members below it are still needed.
+  test('a dead member does not break expansion of its live siblings', () => {
+    const mixed = [
+      { entity_id: 'group.top', state: 'on', attributes: { entity_id: ['light.gone', 'group.inner'] } },
+      { entity_id: 'group.inner', state: 'on', attributes: { entity_id: ['light.kitchen'] } },
+      { entity_id: 'light.kitchen', state: 'on', attributes: {} },
+    ];
+    assert.deepEqual([...expandGroupMembers(['group.top'], mixed)].sort(),
+      ['group.inner', 'group.top', 'light.kitchen']);
+  });
 });


### PR DESCRIPTION
`expandGroupMembers()` adds a group's `attributes.entity_id` members to the allowlist checking only that each one *looks* like an entity id (`isEntityId`), never that HA is actually serving it.

A group's `entity_id` attribute lists its members by id whether or not they are in the state machine. **Most often they are missing because the member is disabled** — a perfectly valid registry entry that simply has no state, so HA will never stream it. Removal and renaming do the same thing but are rarer.

On my instance that is not marginal: **87 Hue room/zone groups list 409 member ids that `get_states` doesn't return, putting 239 of them into a 772-entity allowlist — 31% of it**. So `allowlist: 772 entities` in the log is really 533, and the per-dashboard lines are each 2–37 too high. Harmless to forward (an entry matching no entity forwards nothing), but it is the number people tune the `dashboards` option against — it made three of my dashboards look like they exceeded a budget they were comfortably inside.

> **Correction (I had this wrong in the first version of this description).** I originally wrote that these members had been *renamed or removed*. I had inferred that from the ids being absent from `get_states` and never checked the registry. Checked since: **all 239 are present in the entity registry and all 239 are disabled** — `disabled_by: "device"`, the devices disabled by the user, every one a Hue bulb. Nothing was renamed and nothing was removed; the owner had deliberately disabled the individual bulbs and kept the room/zone groups, which is ordinary curation to control entity count. The fix is unchanged and still correct — a disabled entity can never be streamed — but the reason matters, because "stale data" invites a cleanup that would be wrong here.

Every other path into the allowlist is already gated on the id being real: the config-text scrape in `ha_ws_trim_proxy.mjs` checks `real.has()`, and the rendered-template scrape in `expandAutoEntities` checks `ctx.byId.has()`. This was the one that was not.

**Change:** one condition — `byId.has(e)`. `byId` is built from `get_states`, so it already means "in the state machine" rather than "in the registry", which is the right test.

**Tests:** three added to `test/extract.filters.test.mjs` — a member with no state is not forwarded, an all-stateless list contributes nothing, and (the regression this could plausibly have caused) a stateless member does not break expansion of its live siblings. 75 → 78 tests, 0 fail.

**Verified against live data.** Running `allowlistFor()`/`buildAllow()` with both expansions in one process, against one snapshot of a 5,565-entity instance with 50 dashboards:

| | union | not served | per dashboard (min/med/max) |
|---|---|---|---|
| before | 772 | 239 | 138 / 151 / 213 |
| after | 533 | 0 | 136 / 144 / 176 |

**Live entities lost: 0.** It removes only ids HA was never going to send, so no card can lose data.

**Deliberately not addressed here:** an id under `entity:` / `entity_id:` in a dashboard is still added on shape alone, so a card referencing a disabled or deleted entity still contributes one. I have none of those, and it is arguably intentional — allowlisting an entity that is temporarily disabled — so it seemed a separate decision rather than part of this fix.
