### PR TITLE
Per-connection scoping: give each kiosk its own dashboard's allowlist

### DIFF
--- a/websocket-stripper/CHANGELOG.md
+++ b/websocket-stripper/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## 0.3.0
+
+**Per-connection scoping, off by default** (`scope_per_connection`). The allowlist is the union of
+every configured dashboard and every connection gets all of it, so adding a dashboard grows what
+*every other* kiosk receives — the trim erodes as the list grows and nothing says so. Measured on a
+50-dashboard fleet: a panel held **535** entities where its own dashboard needed **148**, and adding
+three dashboards took one panel from 149 to 187 without that panel being touched. Tuning cannot fix
+it — 183 of those entities appeared on exactly one dashboard, and only 125 on all 50.
+
+The websocket is a separate connection from the page load, so it carries no dashboard path. It does
+carry an `auth` frame, and one `auth/current_user` call says which HA user it belongs to. With the
+option on, a connection receives only the dashboards mapped to its user in `scope_by_user` — keyed
+on the user **id**, which survives a rename where a display name does not. **Every** fallback lands
+on the union: unknown user, no mapping, a scope naming an unserved dashboard, a lookup that fails or
+times out. So an unconfigured or misconfigured install behaves exactly as it did before rather than
+being narrowed, and an *empty* allowlist is still never forwarded, because HA reads that as "no
+filter".
+
+The lookup runs on a **separate short-lived socket**, not the browser's. It has to: HA requires
+message ids to increase on a connection, so injecting a command onto the browser's socket either
+collides with the frontend's sequence or poisons every later message on it. For the same reason,
+holding a frame while the lookup completes holds **every** frame after it — releasing one out of
+order would earn an `id_reuse` rejection on the frame the frontend is waiting for. The lookup starts
+the moment the token crosses, overlapping the browser's own auth round trip, and happens only then:
+an access token is good for 30 minutes, but HA never re-checks one on an already-open socket, so a
+page up for hours holds a long-expired token beside a perfectly healthy connection.
+
+**Allowlist growth now recycles only the connections it affects.** Previously any growth dropped
+every open connection, so a registry event anywhere — a device renamed, an entity added somewhere
+unrelated — reconnected every kiosk at once. On that fleet: 8 whole-fleet reconnect storms in 76
+minutes, of which 16 of 20 recomputes were registry churn and exactly 1 was a dashboard edit.
+
+The test mock now enforces HA's increasing-id rule, so anything that reorders frames fails loudly
+rather than passing here and breaking against a real instance.
+
 ## 0.2.3 — 2026-08-23
 
 Filter resolution and reverse-proxy fixes, all from reported issues.

--- a/websocket-stripper/DOCS.md
+++ b/websocket-stripper/DOCS.md
@@ -12,6 +12,8 @@ uses, so kiosk/wall-panel pages load fast on large instances — with no loss of
 | `always_forward` | list | Entities to forward even if no listed dashboard uses them. Each item is a literal `entity_id` or a `/regex/` (matched against all entities). |
 | `never_forward` | list | Entities to never forward. Applied last — **wins** over `always_forward` and dashboard detection. Literal or `/regex/`. |
 | `strip_entities` | bool | `true` (default) strips the websocket to the allowlist. `false` = full passthrough (for A/B comparison). |
+| `scope_per_connection` | bool | `false` (default). When `true`, a connection receives only the dashboards mapped to the HA user it signed in as, instead of the union of all of them. See [Per-connection scoping](#per-connection-scoping). |
+| `scope_by_user` | list of `{user, dashboards}` | The map `scope_per_connection` reads. `user` is the HA user's **id**; `dashboards` is a subset of `dashboards` above. |
 | `port` | int | Port the add-on listens on (default `8099`). Because it runs with `host_network: true`, this option is how you move it off `8099` — the **Network** tab can't remap a host-network port. Change it if `8099` collides with another add-on (e.g. Zigbee2MQTT). |
 | `ha_base` | string | Optional. Override the Home Assistant base URL the add-on proxies to (default `http://homeassistant:8123`). Set this if `host_network` is on and the internal `homeassistant` hostname doesn't resolve — e.g. `http://192.168.4.2:8123`. |
 | `allow_ws_url` | string | Optional. Override the websocket URL used once at startup to precompute the allowlist (default `ws://supervisor/core/websocket`). Set if `supervisor` doesn't resolve under `host_network` — e.g. `ws://192.168.4.2:8123/api/websocket` (also requires a token via `ALLOW_TOKEN`). |
@@ -102,6 +104,54 @@ editing `config.yaml` and rebuilding. If you log in normally (or with a token) a
 rely on trusted-network auto-login, that's a reasonable local change; you then trim the
 port via the Network tab as usual. The default stays `true` so the documented kiosk login
 keeps working out of the box.
+
+## Per-connection scoping
+
+**The problem it solves.** The allowlist is the **union** of every dashboard in `dashboards`, and
+every connection gets all of it. With two or three lean kiosks that is fine. It stops being fine as
+the list grows, because adding a dashboard grows what *every other* kiosk receives — the trim you
+measured on day one quietly erodes, and nothing tells you. On a 50-dashboard fleet, measured: a
+panel held **535** entities where its own dashboard needed **148**, and adding three dashboards took
+one panel from 149 to 187 **without that panel being touched**.
+
+Tuning `dashboards` cannot fix it. On that fleet 183 entities appeared on exactly one dashboard and
+only 125 on all 50, so even deleting every shared entity would leave hundreds.
+
+**Why it keys on the user.** The websocket is a *separate connection* from the page load, so it
+carries no dashboard path — the proxy cannot tell which dashboard you are about to open. It can tell
+**who you are**: the browser's `auth` frame crosses the proxy, and one `auth/current_user` call
+answers it. So the requirement is that **each kiosk signs in as its own HA user**. One shared login
+cannot be told apart.
+
+```yaml
+dashboards:
+  - kitchen-kiosk
+  - hallway-kiosk
+scope_per_connection: true
+scope_by_user:
+  - user: 3f2a...            # Settings → People → the user → the id in the URL
+    dashboards: [kitchen-kiosk]
+  - user: 8c1b...
+    dashboards: [hallway-kiosk]
+```
+
+**Use the user *id*, not the display name.** The id survives a rename; a name does not — and a scope
+that stops matching does not fail loudly, it falls back to the union, which looks like nothing
+happening.
+
+**Everything unrecognised falls back to the union**, i.e. to the behaviour you get with the option
+off: a user with no scope, a lookup that fails or times out, a scope naming a dashboard that is not
+in `dashboards`. That is deliberate — an *empty* allowlist means "no filter" to Home Assistant, so
+falling back to nothing would relay the entire firehose. It does mean a misconfigured scope is
+silent, so **check the log**: a scoped connection prints `scoped connection: user 3f2a… ->
+kitchen-kiosk (148 entities, union is 535)`, and a scope naming an unserved dashboard warns at boot.
+
+**A side effect worth knowing about.** When the allowlist grows, open connections are dropped so the
+frontend reconnects and picks up the new entities. Under a union, *any* growth is growth for
+everyone — so a registry event anywhere recycles every kiosk at once. On the fleet above that was 8
+whole-fleet reconnect storms in 76 minutes, and only 1 of 20 recomputes came from anyone editing a
+dashboard. With scoping on, a dashboard edit reaches the kiosks showing that dashboard and nobody
+else.
 
 ## Notes & limits
 

--- a/websocket-stripper/config.yaml
+++ b/websocket-stripper/config.yaml
@@ -1,5 +1,5 @@
 name: WebSocket Stripper
-version: "0.2.3"
+version: "0.3.0"
 slug: websocket_stripper
 stage: stable
 description: Serves your real HA dashboards but trims the entity websocket to only what each dashboard uses — fast kiosk loads, full fidelity.
@@ -32,6 +32,24 @@ options:
   always_forward: []
   never_forward: []
   strip_entities: true
+  # PER-CONNECTION SCOPING. Off by default, so an existing install behaves exactly as before.
+  #
+  # With `dashboards` holding more than one kiosk, the allowlist is their UNION and every
+  # connection gets all of it -- so adding a dashboard grows what every OTHER kiosk receives.
+  # On a 50-dashboard fleet that is a panel holding 535 entities where its own dashboard needs
+  # 148. Turn this on and each connection gets only the dashboards mapped to the HA user it
+  # authenticated as; anything unrecognised falls back to the union, i.e. to today's behaviour.
+  #
+  # It only helps if each kiosk signs in as its OWN HA user. One shared user cannot be told
+  # apart, and the websocket carries no other identity -- the dashboard is not in the request
+  # path, because the ws is a separate connection from the page load.
+  scope_per_connection: false
+  # user: the HA user's ID (Settings -> People -> the user -> the id in the URL), not the name.
+  #   The id survives a rename; a name does not, and a scope that stops matching fails SILENTLY
+  #   back to the union.
+  # dashboards: a subset of `dashboards` above. Entries here are not added to the allowlist --
+  #   list them in `dashboards` too, or they resolve to nothing.
+  scope_by_user: []
   port: 8099
   ha_base: ""
   allow_ws_url: ""
@@ -43,6 +61,11 @@ schema:
   never_forward:
     - str
   strip_entities: bool
+  scope_per_connection: "bool?"
+  scope_by_user:
+    - user: str
+      dashboards:
+        - str
   port: "int(1,65535)?"
   ha_base: "str?"
   allow_ws_url: "str?"

--- a/websocket-stripper/ha_ws_trim_proxy.mjs
+++ b/websocket-stripper/ha_ws_trim_proxy.mjs
@@ -27,6 +27,7 @@
 
 import http from 'node:http';
 import fs from 'node:fs';
+import crypto from 'node:crypto';
 import httpProxy from 'http-proxy';
 import { WebSocketServer, WebSocket } from 'ws';
 import { extractEntities, collectTemplates, expandGroupMembers } from './lovelace_extract.mjs';
@@ -42,7 +43,7 @@ const inAddon = !!process.env.SUPERVISOR_TOKEN;
 // Bump together with config.yaml `version`. Logged at boot so the add-on log shows exactly
 // which code is running — the only reliable way to tell a Rebuild actually picked up changes
 // (a local add-on bakes in whatever files are in the host's /addons folder, not GitHub).
-const VERSION = '0.2.3';
+const VERSION = '0.3.0';
 
 const toList = (v) => (Array.isArray(v) ? v : String(v ?? '').split(/[\n,]/))
   .map((s) => String(s).trim()).filter(Boolean);
@@ -73,6 +74,47 @@ function parseRules(v) {
 const ALWAYS = parseRules(OPT.always_forward ?? process.env.ALWAYS_FORWARD);
 const NEVER = parseRules(OPT.never_forward ?? process.env.NEVER_FORWARD);
 const matchesAny = (rules, id) => rules.some((r) => (r.re ? r.re.test(id) : r.literal === id));
+
+// ---- per-connection scoping (optional; off by default) ----
+// The allowlist is normally the UNION of every configured dashboard, so each kiosk receives
+// what ALL of them need. With more than a couple of dashboards that dominates: adding one grows
+// what every other kiosk gets, and the trim you measured on day one quietly erodes.
+//
+// The websocket cannot be attributed to a dashboard — it is a separate connection from the page
+// load and carries no path. It CAN be attributed to a user: the browser's `auth` frame crosses
+// this proxy, and one `auth/current_user` call answers who it belongs to. So the map is
+// user -> dashboards, and anything unrecognised falls back to the union, i.e. to the old
+// behaviour. Nothing here can make a connection see LESS than it would have without the option
+// on, except when a scope is deliberately configured for it.
+const SCOPING = !!(OPT.scope_per_connection ?? (process.env.SCOPE_PER_CONNECTION === '1'));
+// user id -> [url_path, ...]. Keyed on the ID: a display name does not survive a rename, and a
+// scope that silently stops matching just falls back to the union, which looks like nothing
+// happening rather than like a fault.
+const SCOPE_BY_USER = new Map();
+// Dev/CLI mode takes the same structure as JSON, so the option is reachable without an
+// options.json — every other option already has an env fallback.
+let scopeRows = Array.isArray(OPT.scope_by_user) ? OPT.scope_by_user : null;
+if (!scopeRows && process.env.SCOPE_BY_USER) {
+  try { scopeRows = JSON.parse(process.env.SCOPE_BY_USER); }
+  catch (e) { console.error(`ERROR: SCOPE_BY_USER is not valid JSON (${e.message}) — ignoring it`); }
+}
+for (const row of (Array.isArray(scopeRows) ? scopeRows : [])) {
+  const user = String(row?.user || '').trim();
+  const dashes = toList(row?.dashboards).filter(Boolean);
+  if (!user || !dashes.length) continue;
+  SCOPE_BY_USER.set(user, [...new Set([...(SCOPE_BY_USER.get(user) || []), ...dashes])]);
+}
+// A scope naming a dashboard that is not served is the failure this warns about: it resolves to
+// an empty set, and an empty set can never be forwarded (that means "no filter" to HA), so the
+// connection would fall back to the union and the scope would do nothing at all — silently.
+if (SCOPING) {
+  for (const [user, dashes] of SCOPE_BY_USER) {
+    const unknown = dashes.filter((d) => !DASH_PATHS.includes(d));
+    if (unknown.length) {
+      console.error(`WARNING: scope_by_user[${user}] names dashboard(s) not in \`dashboards\`: ${unknown.join(', ')} — they resolve to nothing. Add them to \`dashboards\` or remove them here.`);
+    }
+  }
+}
 
 if (!ALLOW_TOKEN) {
   console.error('ERROR: need a token (SUPERVISOR_TOKEN / HA_TOKEN / ALLOW_TOKEN).');
@@ -133,9 +175,13 @@ process.on('unhandledRejection', (e) => {
 });
 
 let ALLOW = new Set();
+// url_path -> that dashboard's own allowlist. Only consulted when SCOPING is on.
+let PER_DASH = new Map();
 // Every live browser <-> HA bridge, so a grown allowlist can reach already-open pages
-// (issue #7). See refreshOpenConnections().
-const openBridges = new Set();
+// (issue #7). Keyed by SCOPE — a url_path, or UNION_SCOPE for a connection on the union — so a
+// dashboard edit only recycles the connections it actually affects. See refreshOpenConnections().
+const UNION_SCOPE = ' union';        // cannot collide with a url_path
+const openBridges = new Map();            // scopeKey -> Set<closeFn>
 // False until the first allowlist lands. HA may still be booting when we start, and injecting
 // an EMPTY allowlist would render every card "unavailable" until a manual reload — so until
 // this flips we refuse /api/websocket upgrades instead (the frontend just keeps retrying).
@@ -213,12 +259,33 @@ async function renderTemplates(cfg, renderTemplate) {
   return out;
 }
 
-// Build the union allowlist over all configured dashboards using an authed rpc().
+// `always_forward` / `never_forward`, applied to ONE set. Called for the union and, when
+// scoping is on, for each dashboard's own set — so a scoped connection still receives the
+// always_forward entities. That matters more than it looks: those are typically the entities
+// that appear on NO dashboard (a kiosk-health helper, a command channel), which is exactly why
+// they need forcing, and a scoped connection has an even smaller set to find them in.
+// `never` is applied after `always`, so never wins. Order preserved from the original.
+function applyOverrides(set, realIds) {
+  const base = set.size;
+  ALWAYS.forEach((r) => {
+    if (r.literal) set.add(r.literal);
+    else realIds.forEach((eid) => { if (r.re.test(eid)) set.add(eid); });
+  });
+  const afterAlways = set.size;
+  [...set].forEach((eid) => { if (matchesAny(NEVER, eid)) set.delete(eid); });
+  return { base, added: afterAlways - base, removed: afterAlways - set.size };
+}
+
+// Build the allowlist over all configured dashboards using an authed rpc().
+// Returns BOTH the union and each dashboard's own set. The per-dashboard sets were always
+// computed here — they were just discarded into the union — so keeping them costs nothing and
+// is what per-connection scoping selects from.
 async function buildAllow(rpc, renderTemplate) {
   const states = await rpc({ type: 'get_states' });
   const realIds = states.map((s) => s.entity_id);
   const registries = await fetchRegistries(rpc);
   const union = new Set();
+  const per = new Map();
   let failed = 0;
   for (const p of DASH_PATHS) {
     try {
@@ -227,6 +294,8 @@ async function buildAllow(rpc, renderTemplate) {
       const set = allowlistFor(cfg, states, registries, tpls);
       log(`  ${p}: ${set.size} entities`);
       set.forEach((e) => union.add(e));
+      applyOverrides(set, realIds);
+      per.set(p, set);
     } catch (e) { failed++; log(`  ${p}: FAILED ${e.message}`); }
   }
   // Any failure at all is worth naming the alternatives for: `config_not_found` means the
@@ -241,15 +310,15 @@ async function buildAllow(rpc, renderTemplate) {
   if (DASH_PATHS.length && failed === DASH_PATHS.length) {
     throw new Error(`no dashboard config available yet (all ${failed} failed) — HA not ready, or none of these url_paths exist`);
   }
-  const baseN = union.size;
-  ALWAYS.forEach((r) => {
-    if (r.literal) union.add(r.literal);
-    else realIds.forEach((eid) => { if (r.re.test(eid)) union.add(eid); });
-  });
-  const afterAlways = union.size;
-  [...union].forEach((eid) => { if (matchesAny(NEVER, eid)) union.delete(eid); });
-  log(`overrides: base ${baseN}, +always ${afterAlways - baseN}, -never ${afterAlways - union.size}`);
-  return union;
+  const ov = applyOverrides(union, realIds);
+  log(`overrides: base ${ov.base}, +always ${ov.added}, -never ${ov.removed}`);
+  if (SCOPING) {
+    const sizes = [...per.values()].map((s) => s.size).sort((a, b) => a - b);
+    if (sizes.length) {
+      log(`per-connection scoping ON: ${SCOPE_BY_USER.size} user scope(s); per-dashboard min ${sizes[0]}, max ${sizes[sizes.length - 1]} vs union ${union.size}`);
+    }
+  }
+  return { union, per };
 }
 
 // Swap in a freshly-computed allowlist and log exactly what changed — the entity ids
@@ -264,16 +333,31 @@ async function buildAllow(rpc, renderTemplate) {
 // including is harmless here by design (see allowlistFor); under-including breaks cards. An
 // actual dashboard/registry edit still replaces, so removals take effect.
 function applyAllow(next, why, { merge = false } = {}) {
-  if (merge) next = new Set([...ALLOW, ...next]);
-  const added = [...next].filter((e) => !ALLOW.has(e)).sort();
-  const removed = [...ALLOW].filter((e) => !next.has(e)).sort();
-  ALLOW = next;
+  let union = next.union;
+  let per = next.per;
+  if (merge) {
+    union = new Set([...ALLOW, ...union]);
+    per = new Map([...per].map(([p, s]) => [p, new Set([...(PER_DASH.get(p) || []), ...s])]));
+    for (const [p, s] of PER_DASH) if (!per.has(p)) per.set(p, s);   // a dashboard that failed this round
+  }
+  const added = [...union].filter((e) => !ALLOW.has(e)).sort();
+  const removed = [...ALLOW].filter((e) => !union.has(e)).sort();
+  // Which SCOPES grew, so only the connections on those get recycled (see
+  // refreshOpenConnections). Computed before the swap, against the previous per-dashboard sets.
+  const grown = new Set();
+  for (const [p, s] of per) {
+    const before = PER_DASH.get(p);
+    if (!before || [...s].some((e) => !before.has(e))) grown.add(p);
+  }
+  if (added.length) grown.add(UNION_SCOPE);
+  ALLOW = union;
+  PER_DASH = per;
   const fmt = (a) => (a.length > 25 ? `${a.slice(0, 25).join(', ')} …(+${a.length - 25} more)` : a.join(', '));
   log(`allowlist ${why}: ${ALLOW.size} entities (+${added.length} -${removed.length})`);
   if (added.length) log(`  +added: ${fmt(added)}`);
   if (removed.length) log(`  -removed: ${fmt(removed)}`);
   if (!added.length && !removed.length) log('  (no change)');
-  if (added.length) refreshOpenConnections();
+  if (grown.size) refreshOpenConnections(grown);
 }
 
 // `subscribe_entities` is sent ONCE per connection and HA has no way to amend a live
@@ -283,10 +367,22 @@ function applyAllow(next, why, { merge = false } = {}) {
 // disconnect, reconnects on its own, and re-subscribes against the current allowlist.
 // Only on GROWTH. A shrink means the open page is carrying entities it no longer needs,
 // which is harmless — and churning every kiosk over a removal would be a bad trade.
-function refreshOpenConnections() {
+//
+// Only the SCOPES that grew. Under a global union any growth anywhere is growth for everyone,
+// so a registry event — a device renamed, a label moved, an entity added somewhere unrelated —
+// recycles every open kiosk at once. Measured on a 50-dashboard fleet: 8 whole-fleet reconnect
+// storms in 76 minutes, and 16 of 20 recomputes came from registry churn rather than from
+// anybody editing a dashboard. With scoping on, a dashboard edit reaches the kiosks showing
+// that dashboard and nobody else.
+function refreshOpenConnections(grown) {
   if (!STRIP || !openBridges.size) return;
-  log(`  reconnecting ${openBridges.size} open dashboard connection(s) to pick up the new entities`);
-  for (const close of [...openBridges]) { try { close(); } catch {} }
+  let n = 0;
+  for (const [scope, set] of openBridges) {
+    if (!grown.has(scope)) continue;
+    n += set.size;
+    for (const close of [...set]) { try { close(); } catch {} }
+  }
+  if (n) log(`  reconnecting ${n} open dashboard connection(s) to pick up the new entities`);
 }
 
 // ---- persistent control connection: compute the allowlist + watch for dashboard edits ----
@@ -366,8 +462,10 @@ function startController() {
           try {
             backoff = 1000; attempts = 0;
             const next = await buildAllow(rpc, renderTemplate);
-            if (!settled) { ALLOW = next; settled = true; ALLOW_READY = true; resolve(ALLOW); }
-            else applyAllow(next, 'recomputed (reconnect)', { merge: true });
+            if (!settled) {
+              ALLOW = next.union; PER_DASH = next.per;
+              settled = true; ALLOW_READY = true; resolve(ALLOW);
+            } else applyAllow(next, 'recomputed (reconnect)', { merge: true });
             // lovelace_updated -> a dashboard's cards changed. The *_registry_updated
             // events -> a device moved area, a label was (un)assigned, etc., which can
             // change what an area/label/device/integration auto-entities filter resolves
@@ -509,6 +607,72 @@ server.on('upgrade', (req, socket, head) => {
   }
 });
 
+// ---- who does this connection belong to? (per-connection scoping) ----
+// HA rejects a message whose id is not greater than the highest seen on that connection
+// (`id_reuse`), so the proxy CANNOT ask `auth/current_user` on the browser's own socket: a low
+// id collides with the frontend's sequence, and a high id poisons every later browser message
+// for the life of the connection. It asks on a socket of its own instead, using the token it
+// just watched cross the handshake, and closes it again.
+//
+// AT THE HANDSHAKE, NEVER LATER. An access token is good for 30 minutes, but HA never re-checks
+// one on an already-open socket — so a kiosk page that has been up for hours holds a long-dead
+// token beside a perfectly healthy connection (measured: 3,469 s past expiry). The token is
+// guaranteed valid at exactly one moment, when the browser sends it, because the frontend
+// refreshes an expired one before it connects. Re-resolving later would fail, fall back to the
+// union, and look exactly like a kiosk that was never mapped.
+const RESOLVE_TIMEOUT = 5000;
+const USER_CACHE_TTL = 10 * 60 * 1000;      // deliberately under the 30 min token lifetime
+const userCache = new Map();                // sha256(token) -> { user, at }
+
+function resolveUser(token) {
+  // Keyed on a HASH. The cache holds the ANSWER, not the credential, so nothing here can
+  // replay a token and an expired one cannot linger in memory as a usable secret.
+  const key = crypto.createHash('sha256').update(token).digest('hex');
+  const hit = userCache.get(key);
+  if (hit && Date.now() - hit.at < USER_CACHE_TTL) return Promise.resolve(hit.user);
+  return new Promise((resolve) => {
+    let ws; let done = false;
+    const finish = (user) => {
+      if (done) return;
+      done = true;
+      clearTimeout(timer);
+      try { if (ws) ws.close(); } catch { /* already gone */ }
+      if (user) userCache.set(key, { user, at: Date.now() });
+      resolve(user);
+    };
+    const timer = setTimeout(() => finish(null), RESOLVE_TIMEOUT);
+    timer.unref?.();
+    try { ws = new WebSocket(HA_WS, { handshakeTimeout: RESOLVE_TIMEOUT }); }
+    catch { return finish(null); }
+    ws.on('error', (e) => { logThrottled(`resolve:${e.code || e.message}`, `user lookup failed (${e.message}) — connection falls back to the union allowlist`); finish(null); });
+    ws.on('close', () => finish(null));
+    ws.on('message', (raw) => {
+      let m; try { m = JSON.parse(raw.toString()); } catch { return; }
+      if (m.type === 'auth_required') return ws.send(JSON.stringify({ type: 'auth', access_token: token }));
+      if (m.type === 'auth_invalid') return finish(null);
+      // `auth/current_user` needs no admin rights — it is what populates `hass.user` in the
+      // frontend for every user, including a non-admin kiosk account.
+      if (m.type === 'auth_ok') return ws.send(JSON.stringify({ id: 1, type: 'auth/current_user' }));
+      if (m.id === 1 && m.type === 'result') finish((m.success && m.result && m.result.id) || null);
+    });
+  });
+}
+
+// The allowlist for a resolved user: the union of the dashboards mapped to them.
+// EVERY fallback lands on the global union, never on an empty set — HA reads an empty
+// entity_ids as "no filter", so an empty scope would relay the very firehose this exists to
+// prevent. An unmapped user (someone's laptop, an admin, a kiosk not in the map) therefore
+// behaves exactly as it did before the option existed.
+function scopeFor(userId) {
+  if (!SCOPING || !userId) return { keys: [UNION_SCOPE], allow: ALLOW };
+  const dashes = SCOPE_BY_USER.get(userId);
+  if (!dashes || !dashes.length) return { keys: [UNION_SCOPE], allow: ALLOW };
+  const allow = new Set();
+  for (const d of dashes) for (const e of (PER_DASH.get(d) || [])) allow.add(e);
+  if (!allow.size) return { keys: [UNION_SCOPE], allow: ALLOW };
+  return { keys: dashes, allow };
+}
+
 function bridge(browserWs) {
   const haWs = new WebSocket(HA_WS, { perMessageDeflate: true, maxPayload: 0 });
   const getStatesIds = new Set();
@@ -518,7 +682,36 @@ function bridge(browserWs) {
 
   haWs.on('open', () => { haOpen = true; queue.forEach((s) => haWs.send(s)); queue.length = 0; });
 
-  browserWs.on('message', (raw) => {
+  // What THIS connection is filtered against. Starts as the union — which is what it would have
+  // received anyway — and narrows only if the user resolves to a configured scope.
+  let allow = ALLOW;
+  let scopeKeys = [UNION_SCOPE];
+  let scopeSettled = !SCOPING;        // nothing to wait for when the option is off
+  let resolveStarted = false;
+  const held = [];
+  let holdTimer = null;
+
+  // Only these two need the scope. But holding ONE message means holding EVERY message after
+  // it: HA requires ids to increase, so releasing a held frame after a later one has already
+  // gone through would make HA reject the held one with `id_reuse` — the frontend would see its
+  // own `get_states` fail for no visible reason. The hold is a barrier, not a filter.
+  const needsScope = (m) => !!m && (m.type === 'get_states'
+    || (m.type === 'subscribe_entities' && !m.entity_ids));
+
+  function onUser(userId) {
+    if (scopeSettled) return;
+    clearTimeout(holdTimer);
+    const sc = scopeFor(userId);
+    allow = sc.allow;
+    setScopeKeys(sc.keys);
+    if (sc.keys[0] !== UNION_SCOPE) {
+      log(`scoped connection: user ${String(userId).slice(0, 8)}… -> ${sc.keys.join(', ')} (${allow.size} entities, union is ${ALLOW.size})`);
+    }
+    scopeSettled = true;
+    for (const raw of held.splice(0)) forwardBrowser(raw);
+  }
+
+  function forwardBrowser(raw) {
     let s = raw.toString(); let m;
     try { m = JSON.parse(s); } catch { return toHA(s); }
     if (STRIP && m && m.type === 'get_states') getStatesIds.add(m.id);
@@ -526,16 +719,37 @@ function bridge(browserWs) {
       // Belt-and-braces to the upgrade gate: an empty entity_ids is NOT "subscribe to
       // nothing", it's "no filter" (HA: `set(msg["entity_ids"]) or None`). Sending one would
       // invert the add-on's entire purpose, so drop the connection instead.
-      if (!ALLOW.size) {
+      if (!allow.size) {
         logThrottled('empty-allow', 'ERROR: refusing subscribe_entities — the allowlist is empty, and forwarding that would stream EVERY entity. Check the `dashboards` option.');
         return close();
       }
-      m.entity_ids = [...ALLOW];           // HA now streams only the allowlist
+      m.entity_ids = [...allow];           // HA now streams only this connection's allowlist
       subEntityIds.add(m.id);              // remember it, to defensively re-filter its events
       s = JSON.stringify(m);
     }
     if (m && m.type === 'unsubscribe_events' && m.subscription != null) subEntityIds.delete(m.subscription);
     toHA(s);
+  }
+
+  browserWs.on('message', (raw) => {
+    if (!SCOPING) return forwardBrowser(raw);
+    let m; try { m = JSON.parse(raw.toString()); } catch { m = null; }
+    // Start the lookup the moment the token crosses — that overlaps the browser's own auth
+    // round trip and the frontend's startup, so the answer is normally in hand before it
+    // subscribes. The frame itself is relayed untouched and immediately; auth is never delayed.
+    if (!resolveStarted && m && m.type === 'auth' && m.access_token) {
+      resolveStarted = true;
+      resolveUser(m.access_token).then(onUser, () => onUser(null));
+      return forwardBrowser(raw);
+    }
+    if (!scopeSettled && (held.length || needsScope(m))) {
+      // Bounded even if the client never authenticates or HA never answers: the connection
+      // must not stall on a lookup, so give up and use the union.
+      if (!held.length) holdTimer = setTimeout(() => onUser(null), RESOLVE_TIMEOUT);
+      held.push(raw);
+      return;
+    }
+    forwardBrowser(raw);
   });
 
   haWs.on('message', (raw) => {
@@ -543,7 +757,7 @@ function bridge(browserWs) {
     try { m = JSON.parse(s); } catch { return safeSend(s); }
     if (STRIP && m && m.type === 'result' && getStatesIds.has(m.id) && Array.isArray(m.result)) {
       const before = m.result.length;
-      m.result = m.result.filter((e) => ALLOW.has(e.entity_id));
+      m.result = m.result.filter((e) => allow.has(e.entity_id));
       getStatesIds.delete(m.id);
       s = JSON.stringify(m);
       log(`get_states trimmed ${before} -> ${m.result.length}`);
@@ -558,12 +772,12 @@ function bridge(browserWs) {
       const ev = m.event; let changed = false;
       for (const k of ['a', 'c']) {
         if (ev[k]) for (const eid of Object.keys(ev[k])) {
-          if (!ALLOW.has(eid)) { delete ev[k][eid]; changed = true; }
+          if (!allow.has(eid)) { delete ev[k][eid]; changed = true; }
         }
       }
       if (Array.isArray(ev.r)) {
         const before = ev.r.length;
-        ev.r = ev.r.filter((eid) => ALLOW.has(eid));
+        ev.r = ev.r.filter((eid) => allow.has(eid));
         if (ev.r.length !== before) changed = true;
       }
       if (changed) s = JSON.stringify(m);
@@ -572,8 +786,32 @@ function bridge(browserWs) {
   });
 
   function safeSend(s) { try { if (browserWs.readyState === 1) browserWs.send(s); } catch {} }
-  const close = () => { openBridges.delete(close); try { browserWs.close(); } catch {} try { haWs.close(); } catch {} };
-  openBridges.add(close);            // so a grown allowlist can recycle this connection (#7)
+
+  // Registered under EVERY dashboard in its scope (or under UNION_SCOPE), so growth in any one
+  // of them recycles this connection and growth anywhere else does not.
+  const unregister = () => {
+    for (const k of scopeKeys) {
+      const set = openBridges.get(k);
+      if (!set) continue;
+      set.delete(close);
+      if (!set.size) openBridges.delete(k);
+    }
+  };
+  const close = () => {
+    clearTimeout(holdTimer);
+    unregister();
+    try { browserWs.close(); } catch {}
+    try { haWs.close(); } catch {}
+  };
+  function setScopeKeys(keys) {
+    unregister();
+    scopeKeys = keys;
+    for (const k of scopeKeys) {
+      if (!openBridges.has(k)) openBridges.set(k, new Set());
+      openBridges.get(k).add(close);
+    }
+  }
+  setScopeKeys(scopeKeys);           // so a grown allowlist can recycle this connection (#7)
   browserWs.on('close', close); browserWs.on('error', close);
   haWs.on('close', close);
   haWs.on('error', (e) => { logThrottled(`haws:${e.code || e.message}`, `HA ws error ${e.message}`); close(); });

--- a/websocket-stripper/lovelace_extract.mjs
+++ b/websocket-stripper/lovelace_extract.mjs
@@ -216,6 +216,18 @@ export function collectTemplates(config) {
 // only the group entity in the config; the members live in the group's `entity_id` attribute
 // at runtime and appear nowhere in the dashboard (issue #4). Pull them in transitively so a
 // group on the allowlist brings its members with it. Bounded in case a group cycles.
+//
+// A member must actually EXIST. `isEntityId` is only a shape test, and a group's member list
+// can outlive its members — an entity is renamed or removed and nothing rewrites the lists that
+// point at it. Those ids then enter the allowlist, match nothing, and inflate every count the
+// proxy reports. Measured on one instance: 87 light groups listing 409 dead members put 239
+// phantom ids into a 772-entity allowlist — 31% of it. Harmless to forward (an entry matching
+// no entity forwards nothing), but it makes `allowlist: N entities` wrong by a third, and that
+// is the number people tune the `dashboards` option against.
+//
+// Every other path into the allowlist is already gated on the id being real: the config-text
+// scrape in ha_ws_trim_proxy.mjs checks `real.has()`, and the rendered-template scrape below
+// checks `ctx.byId.has()`. This was the one that was not.
 export function expandGroupMembers(ids, allStates = [], maxDepth = 5) {
   const byId = new Map(allStates.map((s) => [s.entity_id, s]));
   const out = new Set(ids);
@@ -225,7 +237,7 @@ export function expandGroupMembers(ids, allStates = [], maxDepth = 5) {
     for (const id of frontier) {
       const members = byId.get(id)?.attributes?.entity_id;
       if (!Array.isArray(members)) continue;
-      for (const e of members) if (isEntityId(e) && !out.has(e)) { out.add(e); next.push(e); }
+      for (const e of members) if (isEntityId(e) && byId.has(e) && !out.has(e)) { out.add(e); next.push(e); }
     }
     frontier = next;
   }

--- a/websocket-stripper/lovelace_extract.mjs
+++ b/websocket-stripper/lovelace_extract.mjs
@@ -217,13 +217,19 @@ export function collectTemplates(config) {
 // at runtime and appear nowhere in the dashboard (issue #4). Pull them in transitively so a
 // group on the allowlist brings its members with it. Bounded in case a group cycles.
 //
-// A member must actually EXIST. `isEntityId` is only a shape test, and a group's member list
-// can outlive its members — an entity is renamed or removed and nothing rewrites the lists that
-// point at it. Those ids then enter the allowlist, match nothing, and inflate every count the
-// proxy reports. Measured on one instance: 87 light groups listing 409 dead members put 239
-// phantom ids into a 772-entity allowlist — 31% of it. Harmless to forward (an entry matching
-// no entity forwards nothing), but it makes `allowlist: N entities` wrong by a third, and that
-// is the number people tune the `dashboards` option against.
+// A member must be IN THE STATE MACHINE. `isEntityId` is only a shape test, and a group's
+// `entity_id` attribute lists members by id whether or not HA is currently serving them — most
+// often because the member is DISABLED, and also if it has been removed or renamed. A disabled
+// entity is a perfectly valid registry entry; it simply has no state, so HA will never stream
+// it and allowlisting it can only ever be dead weight.
+//
+// Measured on one instance: 87 Hue room/zone groups listed 409 member ids that `get_states`
+// does not return, putting 239 of them into a 772-entity allowlist — 31% of it. Checked rather
+// than assumed: all 239 were present in the entity registry and all were disabled
+// (`disabled_by: device`, the devices disabled by the user) — deliberate curation to control
+// entity count, not stale data. Harmless to forward (an entry matching no entity forwards
+// nothing), but it makes `allowlist: N entities` wrong by a third, and that is the number
+// people tune the `dashboards` option against.
 //
 // Every other path into the allowlist is already gated on the id being real: the config-text
 // scrape in ha_ws_trim_proxy.mjs checks `real.has()`, and the rendered-template scrape below

--- a/websocket-stripper/package-lock.json
+++ b/websocket-stripper/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ha-websocket-stripper",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ha-websocket-stripper",
-      "version": "0.2.3",
+      "version": "0.3.0",
       "dependencies": {
         "http-proxy": "^1.18.1",
         "ws": "^8.18.0"

--- a/websocket-stripper/package.json
+++ b/websocket-stripper/package.json
@@ -2,7 +2,7 @@
   "name": "ha-websocket-stripper",
   "private": true,
   "type": "module",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "description": "Reverse proxy that serves the real HA frontend but trims the entity websocket to a dashboard allowlist.",
   "main": "ha_ws_trim_proxy.mjs",
   "scripts": {

--- a/websocket-stripper/test/extract.filters.test.mjs
+++ b/websocket-stripper/test/extract.filters.test.mjs
@@ -142,20 +142,21 @@ describe('group membership expansion (issue #4)', () => {
       ['group.a', 'group.b', 'light.kitchen']);
   });
 
-  // A group's member list can outlive its members: an entity is renamed or removed and
-  // nothing rewrites the lists pointing at it. `isEntityId` is only a shape test, so those
-  // ids used to enter the allowlist and inflate every count the proxy reports.
-  test('a member that no longer exists is not forwarded', () => {
+  // A group's `entity_id` attribute lists members whether or not HA is serving them — most
+  // often because the member is DISABLED (a valid registry entry with no state), and also if
+  // it was removed or renamed. `isEntityId` is only a shape test, so those ids used to enter
+  // the allowlist and inflate every count the proxy reports.
+  test('a member with no state is not forwarded', () => {
     const stale = [
       { entity_id: 'light.hallway', state: 'off', attributes: { entity_id: ['light.hallway_1', 'light.hallway_2'] } },
       { entity_id: 'light.hallway_1', state: 'off', attributes: {} },
-      // light.hallway_2 was renamed away; the group's list still names it
+      // light.hallway_2 has no state (disabled, or removed); the group still names it
     ];
     assert.deepEqual([...expandGroupMembers(['light.hallway'], stale)].sort(),
       ['light.hallway', 'light.hallway_1']);
   });
 
-  test('a group whose whole member list is dead contributes nothing', () => {
+  test('a group whose members all lack state contributes nothing', () => {
     const allDead = [
       { entity_id: 'light.dining', state: 'on', attributes: { entity_id: ['light.dining_1', 'light.dining_2'] } },
     ];
@@ -164,7 +165,7 @@ describe('group membership expansion (issue #4)', () => {
 
   // Transitive expansion must not be stopped by a dead id in the middle of a chain: the
   // live members below it are still needed.
-  test('a dead member does not break expansion of its live siblings', () => {
+  test('a stateless member does not break expansion of its live siblings', () => {
     const mixed = [
       { entity_id: 'group.top', state: 'on', attributes: { entity_id: ['light.gone', 'group.inner'] } },
       { entity_id: 'group.inner', state: 'on', attributes: { entity_id: ['light.kitchen'] } },

--- a/websocket-stripper/test/extract.filters.test.mjs
+++ b/websocket-stripper/test/extract.filters.test.mjs
@@ -141,4 +141,36 @@ describe('group membership expansion (issue #4)', () => {
     assert.deepEqual([...expandGroupMembers(['group.a'], cyclic)].sort(),
       ['group.a', 'group.b', 'light.kitchen']);
   });
+
+  // A group's member list can outlive its members: an entity is renamed or removed and
+  // nothing rewrites the lists pointing at it. `isEntityId` is only a shape test, so those
+  // ids used to enter the allowlist and inflate every count the proxy reports.
+  test('a member that no longer exists is not forwarded', () => {
+    const stale = [
+      { entity_id: 'light.hallway', state: 'off', attributes: { entity_id: ['light.hallway_1', 'light.hallway_2'] } },
+      { entity_id: 'light.hallway_1', state: 'off', attributes: {} },
+      // light.hallway_2 was renamed away; the group's list still names it
+    ];
+    assert.deepEqual([...expandGroupMembers(['light.hallway'], stale)].sort(),
+      ['light.hallway', 'light.hallway_1']);
+  });
+
+  test('a group whose whole member list is dead contributes nothing', () => {
+    const allDead = [
+      { entity_id: 'light.dining', state: 'on', attributes: { entity_id: ['light.dining_1', 'light.dining_2'] } },
+    ];
+    assert.deepEqual([...expandGroupMembers(['light.dining'], allDead)], ['light.dining']);
+  });
+
+  // Transitive expansion must not be stopped by a dead id in the middle of a chain: the
+  // live members below it are still needed.
+  test('a dead member does not break expansion of its live siblings', () => {
+    const mixed = [
+      { entity_id: 'group.top', state: 'on', attributes: { entity_id: ['light.gone', 'group.inner'] } },
+      { entity_id: 'group.inner', state: 'on', attributes: { entity_id: ['light.kitchen'] } },
+      { entity_id: 'light.kitchen', state: 'on', attributes: {} },
+    ];
+    assert.deepEqual([...expandGroupMembers(['group.top'], mixed)].sort(),
+      ['group.inner', 'group.top', 'light.kitchen']);
+  });
 });

--- a/websocket-stripper/test/mock-ha.mjs
+++ b/websocket-stripper/test/mock-ha.mjs
@@ -31,7 +31,10 @@ const DEFAULT_REGISTRIES = {
 
 // `port` pins the listen port so a test can take HA down and bring it back on the same
 // address — i.e. simulate an HA restart under a running proxy.
-export async function startMockHa({ configs = DEFAULT_CONFIGS, states = STATES, registries = DEFAULT_REGISTRIES, templates = DEFAULT_TEMPLATES, port: fixedPort } = {}) {
+// `users` maps access_token -> the object `auth/current_user` returns. Any token not listed
+// still authenticates (the proxy's own control connection uses `test-token`) but has no user,
+// which is the "cannot be identified" case per-connection scoping has to fall back from.
+export async function startMockHa({ configs = DEFAULT_CONFIGS, states = STATES, registries = DEFAULT_REGISTRIES, templates = DEFAULT_TEMPLATES, users = {}, currentUserDelayMs = 0, port: fixedPort } = {}) {
   const port = fixedPort ?? await getFreePort();
   configs = { ...configs };    // per-mock copy, so a setConfig() in one test can't leak into the next
   const state = {
@@ -85,8 +88,29 @@ export async function startMockHa({ configs = DEFAULT_CONFIGS, states = STATES, 
     ws.send(JSON.stringify({ type: 'auth_required', ha_version: '2026.7.0' }));
     ws.on('message', (raw) => {
       let m; try { m = JSON.parse(raw.toString()); } catch { return; }
-      if (m.type === 'auth') { ws.send(JSON.stringify({ type: 'auth_ok', ha_version: '2026.7.0' })); return; }
+      if (m.type === 'auth') {
+        // Remember WHO authenticated, so `auth/current_user` can answer per connection the way
+        // real HA does — that is how per-connection scoping identifies a kiosk.
+        conn.user = users[m.access_token] || null;
+        ws.send(JSON.stringify({ type: 'auth_ok', ha_version: '2026.7.0' }));
+        return;
+      }
+      // Real HA requires message ids to INCREASE on a connection and answers `id_reuse`
+      // otherwise. Modelled here on purpose: anything in the proxy that reorders frames — a
+      // queue, a hold, a retry — would otherwise pass every test here and fail against a real
+      // instance, where the symptom is the frontend's own get_states failing for no reason.
+      if (typeof m.id === 'number') {
+        if (m.id <= (conn.lastId || 0)) {
+          return ws.send(JSON.stringify({ id: m.id, type: 'result', success: false, error: { code: 'id_reuse', message: 'Identifier values have to increase.' } }));
+        }
+        conn.lastId = m.id;
+      }
       const ok = (result) => ws.send(JSON.stringify({ id: m.id, type: 'result', success: true, result }));
+      if (m.type === 'auth/current_user') {
+        if (!conn.user) return ws.send(JSON.stringify({ id: m.id, type: 'result', success: false, error: { code: 'unknown', message: 'no user' } }));
+        if (currentUserDelayMs) return void setTimeout(() => ok(conn.user), currentUserDelayMs);
+        return ok(conn.user);
+      }
       if (m.type in registries) return ok(registries[m.type]);   // config/*_registry/list
       switch (m.type) {
         case 'get_states': return ok(states);

--- a/websocket-stripper/test/proxy.scoping.test.mjs
+++ b/websocket-stripper/test/proxy.scoping.test.mjs
@@ -1,0 +1,259 @@
+// Per-connection scoping, driven through a real proxy process against the mock HA.
+//
+// The allowlist is normally the UNION of every configured dashboard, so each kiosk receives what
+// ALL of them need and adding a dashboard grows what every other kiosk gets. With
+// `scope_per_connection` on, a connection gets only the dashboards mapped to the HA user it
+// authenticated as, and anything unrecognised falls back to the union.
+//
+// Two properties carry most of the weight here and neither is obvious:
+//
+//   * EVERY fallback lands on the union, never on an empty set. HA reads an empty entity_ids as
+//     "no filter", so an empty scope would relay the whole firehose. That makes "it silently
+//     fell back" indistinguishable from "it worked" unless a test proves the scope actually
+//     discriminates — which is what `a mapped user does NOT see another dashboard's entities`
+//     is for.
+//   * Holding a frame means holding EVERY frame after it. HA requires ids to increase, so
+//     releasing a held get_states after a later message already went through would earn an
+//     `id_reuse` rejection. The mock enforces that rule, so a reordering bug fails loudly.
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { WebSocket } from 'ws';
+import { startMockHa, getFreePort, haClient } from './mock-ha.mjs';
+
+const DIR = path.dirname(fileURLToPath(import.meta.url));
+const PROXY = path.join(DIR, '..', 'ha_ws_trim_proxy.mjs');
+const delay = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// Two kiosks with deliberately disjoint entities, so "did it scope?" has a yes/no answer
+// rather than a size comparison that a fallback could accidentally satisfy.
+const DASH_A = { title: 'A', views: [{ path: 'main', cards: [{ type: 'entities', entities: ['light.living_room', 'sensor.temperature'] }] }] };
+const DASH_B = { title: 'B', views: [{ path: 'main', cards: [{ type: 'entities', entities: ['light.kitchen', 'sensor.humidity'] }] }] };
+const CONFIGS = { 'dash-a': DASH_A, 'dash-b': DASH_B };
+const USERS = {
+  'tok-a': { id: 'user-a', name: 'Kiosk A', is_admin: false },
+  'tok-b': { id: 'user-b', name: 'Kiosk B', is_admin: false },
+  'tok-nomap': { id: 'user-unmapped', name: 'Someone', is_admin: false },
+};
+const SCOPES = JSON.stringify([
+  { user: 'user-a', dashboards: ['dash-a'] },
+  { user: 'user-b', dashboards: ['dash-b'] },
+]);
+
+function spawnProxy({ mock, port, extraEnv = {} }) {
+  const proc = spawn(process.execPath, [PROXY], {
+    env: {
+      ...process.env, HA_BASE: mock.base, HA_TOKEN: 'test-token',
+      DASH_PATHS: 'dash-a,dash-b', PORT: String(port), SUPERVISOR_TOKEN: '', ...extraEnv,
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  let out = '';
+  const listeners = [];
+  const onData = (b) => {
+    out += b.toString();
+    for (let i = listeners.length - 1; i >= 0; i--) {
+      if (listeners[i].re.test(out)) { listeners[i].resolve(out); listeners.splice(i, 1); }
+    }
+  };
+  proc.stdout.on('data', onData);
+  proc.stderr.on('data', onData);
+  const waitForLog = (re, ms = 8000) => new Promise((resolve, reject) => {
+    if (re.test(out)) return resolve(out);
+    const l = { re, resolve: (v) => { clearTimeout(t); resolve(v); } };
+    listeners.push(l);
+    const t = setTimeout(() => {
+      const i = listeners.indexOf(l);
+      if (i >= 0) { listeners.splice(i, 1); reject(new Error(`timeout waiting for ${re}\n--- proxy output ---\n${out}`)); }
+    }, ms);
+  });
+  return { proc, get out() { return out; }, waitForLog, kill: () => proc.kill() };
+}
+
+// The entity set a given kiosk actually receives, asked for the way the frontend does.
+async function seenBy(port, token) {
+  const c = haClient(`ws://127.0.0.1:${port}/api/websocket`, token);
+  await c.authed;
+  const res = await c.rpc({ type: 'get_states' });
+  c.close();
+  assert.ok(res.success !== false, `get_states failed: ${JSON.stringify(res.error)}`);
+  return new Set(res.result.map((s) => s.entity_id));
+}
+
+describe('per-connection scoping is off by default', () => {
+  let mock, proxy, port;
+  before(async () => {
+    mock = await startMockHa({ configs: CONFIGS, users: USERS });
+    port = await getFreePort();
+    // The map is present but the switch is not, which is the upgrade case: an install that
+    // gains the option must behave exactly as it did before anyone turns it on.
+    proxy = spawnProxy({ mock, port, extraEnv: { SCOPE_BY_USER: SCOPES } });
+    await proxy.waitForLog(/union allowlist for/);
+  });
+  after(async () => { proxy.kill(); await mock.close(); });
+
+  it('a mapped user still receives the union', async () => {
+    const seen = await seenBy(port, 'tok-a');
+    assert.ok(seen.has('light.living_room'), 'own dashboard');
+    assert.ok(seen.has('light.kitchen'), 'the OTHER dashboard too — this is the old behaviour');
+  });
+});
+
+describe('per-connection scoping', () => {
+  let mock, proxy, port;
+  before(async () => {
+    mock = await startMockHa({ configs: CONFIGS, users: USERS });
+    port = await getFreePort();
+    proxy = spawnProxy({
+      mock,
+      port,
+      extraEnv: {
+        SCOPE_PER_CONNECTION: '1',
+        SCOPE_BY_USER: SCOPES,
+        // On no dashboard at all, so it can only arrive by being forced.
+        ALWAYS_FORWARD: 'switch.fan',
+        NEVER_FORWARD: 'sensor.temperature',
+      },
+    });
+    await proxy.waitForLog(/union allowlist for/);
+  });
+  after(async () => { proxy.kill(); await mock.close(); });
+
+  it('a mapped user gets its own dashboard and NOT the other one', async () => {
+    const a = await seenBy(port, 'tok-a');
+    assert.ok(a.has('light.living_room'), 'own dashboard present');
+    assert.ok(!a.has('light.kitchen'), 'the other dashboard is NOT forwarded — the scope discriminates');
+    assert.ok(!a.has('sensor.humidity'), 'nor its second entity');
+  });
+
+  it('a different user gets a different set on the same proxy', async () => {
+    const b = await seenBy(port, 'tok-b');
+    assert.ok(b.has('light.kitchen'), 'own dashboard present');
+    assert.ok(!b.has('light.living_room'), 'not dashboard A');
+  });
+
+  it('an unmapped user falls back to the union', async () => {
+    const seen = await seenBy(port, 'tok-nomap');
+    assert.ok(seen.has('light.living_room') && seen.has('light.kitchen'),
+      'both dashboards — a user with no scope must not be narrowed');
+  });
+
+  it('a connection whose user cannot be identified falls back to the union', async () => {
+    // No entry in `users`, so `auth/current_user` fails — an old client, a service account,
+    // anything the lookup cannot answer for.
+    const seen = await seenBy(port, 'tok-unknown');
+    assert.ok(seen.has('light.living_room') && seen.has('light.kitchen'));
+  });
+
+  it('always_forward reaches a SCOPED connection', async () => {
+    // The entities most worth forcing are the ones on no dashboard — a health helper, a command
+    // channel. A scoped connection has an even smaller set to find them in, so if per-scope
+    // overrides were skipped this is where it would show.
+    const a = await seenBy(port, 'tok-a');
+    assert.ok(a.has('switch.fan'), 'always_forward applied to the scope, not only to the union');
+  });
+
+  it('never_forward still wins inside a scope', async () => {
+    const a = await seenBy(port, 'tok-a');
+    assert.ok(!a.has('sensor.temperature'), 'on dashboard A, but excluded');
+  });
+});
+
+describe('a scope that resolves to nothing falls back rather than emptying', () => {
+  let mock, proxy, port;
+  before(async () => {
+    mock = await startMockHa({ configs: CONFIGS, users: USERS });
+    port = await getFreePort();
+    proxy = spawnProxy({
+      mock,
+      port,
+      extraEnv: {
+        SCOPE_PER_CONNECTION: '1',
+        SCOPE_BY_USER: JSON.stringify([{ user: 'user-a', dashboards: ['dash-typo'] }]),
+      },
+    });
+    await proxy.waitForLog(/union allowlist for/);
+  });
+  after(async () => { proxy.kill(); await mock.close(); });
+
+  it('warns that the scope names a dashboard which is not served', () => {
+    assert.match(proxy.out, /scope_by_user\[user-a\] names dashboard\(s\) not in `dashboards`: dash-typo/);
+  });
+
+  it('serves the union instead of an empty allowlist', async () => {
+    // An empty entity_ids means "no filter" to HA, so an empty scope must never be forwarded.
+    // Falling back to the union is the safe direction: the kiosk still works.
+    const seen = await seenBy(port, 'tok-a');
+    assert.ok(seen.has('light.living_room') && seen.has('light.kitchen'));
+  });
+});
+
+describe('a slow user lookup must not reorder frames', () => {
+  let mock, proxy, port;
+  before(async () => {
+    // Slow enough that get_states is certain to arrive while the scope is still unknown.
+    mock = await startMockHa({ configs: CONFIGS, users: USERS, currentUserDelayMs: 600 });
+    port = await getFreePort();
+    proxy = spawnProxy({ mock, port, extraEnv: { SCOPE_PER_CONNECTION: '1', SCOPE_BY_USER: SCOPES } });
+    await proxy.waitForLog(/union allowlist for/);
+  });
+  after(async () => { proxy.kill(); await mock.close(); });
+
+  it('a message sent after a held one does not overtake it', async () => {
+    const c = haClient(`ws://127.0.0.1:${port}/api/websocket`, 'tok-a');
+    await c.authed;
+    // id 1 needs the scope and is held; id 2 does not. If id 2 were forwarded first, HA would
+    // reject id 1 with `id_reuse` — the mock enforces the same rule real HA does.
+    const first = c.rpc({ type: 'get_states' });
+    const second = c.rpc({ type: 'lovelace/dashboards/list' });
+    const [a, b] = await Promise.all([first, second]);
+    assert.ok(a.success !== false, `held get_states rejected: ${JSON.stringify(a.error)}`);
+    assert.ok(b.success !== false, `following message rejected: ${JSON.stringify(b.error)}`);
+    // and it was still scoped, i.e. the wait was not simply skipped
+    const ids = new Set(a.result.map((s) => s.entity_id));
+    assert.ok(!ids.has('light.kitchen'), 'released against the SCOPE, not the union');
+    c.close();
+  });
+});
+
+describe('allowlist growth recycles only the affected scope', () => {
+  let mock, proxy, port;
+  before(async () => {
+    mock = await startMockHa({ configs: CONFIGS, users: USERS });
+    port = await getFreePort();
+    proxy = spawnProxy({ mock, port, extraEnv: { SCOPE_PER_CONNECTION: '1', SCOPE_BY_USER: SCOPES } });
+    await proxy.waitForLog(/union allowlist for/);
+  });
+  after(async () => { proxy.kill(); await mock.close(); });
+
+  it('editing dashboard B leaves a connection scoped to A alone', async () => {
+    // Under a global union ANY growth is growth for everyone, so an unrelated registry event or
+    // a neighbour's dashboard edit recycles every open kiosk. That is the behaviour this
+    // changes, and it is the whole reason the reconnect set is keyed by scope.
+    const a = haClient(`ws://127.0.0.1:${port}/api/websocket`, 'tok-a');
+    await a.authed;
+    await a.rpc({ type: 'get_states' });          // settle the scope before measuring
+    const b = haClient(`ws://127.0.0.1:${port}/api/websocket`, 'tok-b');
+    await b.authed;
+    await b.rpc({ type: 'get_states' });
+
+    let aClosed = false;
+    a.ws.on('close', () => { aClosed = true; });
+    const bClosed = new Promise((res) => b.ws.on('close', res));
+
+    mock.setConfig('dash-b', {
+      title: 'B',
+      views: [{ path: 'main', cards: [{ type: 'entities', entities: ['light.kitchen', 'sensor.humidity', 'light.bedroom'] }] }],
+    });
+    mock.fireLovelaceUpdated('dash-b');
+
+    await proxy.waitForLog(/reconnecting 1 open dashboard connection/, 10000);
+    await bClosed;
+    assert.equal(aClosed, false, 'the connection scoped to dash-a was NOT recycled');
+    assert.equal(a.ws.readyState, WebSocket.OPEN, 'and is still open');
+    a.close();
+  });
+});


### PR DESCRIPTION
Adds `scope_per_connection` — **off by default**, so an existing install is unchanged until you turn it on.

> Stacked on #12. Until that merges, this PR's diff also shows its one-line commit.

## The problem

The allowlist is the **union** of every dashboard in `dashboards`, and every connection gets all of it. With two or three lean kiosks that's fine. It stops being fine as the list grows, because adding a dashboard grows what *every other* kiosk receives — the trim you measured on day one erodes and nothing tells you.

Measured on a 50-dashboard fleet: a panel held **535** entities where its own dashboard needed **148**, and adding three dashboards took one panel from **149 → 187 without that panel being touched**.

Tuning `dashboards` can't fix it: 183 of those entities appeared on exactly one dashboard and only 125 on all 50, so even deleting every shared entity leaves hundreds.

## The approach

The websocket is a separate connection from the page load, so it carries no dashboard path — the proxy can't tell which dashboard you're about to open. It *can* tell **who you are**: the browser's `auth` frame crosses the proxy, and one `auth/current_user` call answers it. So the map is user → dashboards.

`buildAllow()` already computed each dashboard's set and then discarded it into the union, so most of this is *not deleting it*.

```yaml
scope_per_connection: true
scope_by_user:
  - user: 3f2a...          # the user's ID, not their name
    dashboards: [kitchen-kiosk]
```

**Every fallback lands on the union** — unknown user, no mapping, a scope naming an unserved dashboard, a lookup that fails or times out. Nothing can make a connection see *less* than it would have with the option off, and an empty allowlist is still never forwarded (HA reads that as "no filter").

## Two things that forced the design

**The lookup runs on a separate short-lived socket, not the browser's.** HA requires message ids to *increase* on a connection — a lower id after a higher one is rejected with `id_reuse`. So injecting a command onto the browser's socket either collides with the frontend's sequence or poisons every later message on it. Verified that a second concurrent socket with the same token authenticates fine and leaves the first usable.

**Holding a frame means holding every frame after it.** Same rule: releasing a held `get_states` after a later message already went through earns an `id_reuse` rejection on the frame the frontend is waiting for. The hold is a barrier, not a filter. The test mock now enforces HA's increasing-id rule so anything that reorders frames fails loudly here rather than against a real instance.

**The lookup happens at the handshake and never later.** An access token lives 1,800 s but HA never re-checks one on an already-open socket, so a page up for hours holds a long-expired token beside a perfectly healthy connection (measured at 3,469 s past expiry). The token is good at exactly one moment — when the browser sends it, because the frontend refreshes an expired one before connecting.

## Also: growth now recycles only the connections it affects

Previously any growth dropped **every** open connection, so a registry event anywhere — a device renamed, an entity added somewhere unrelated — reconnected every kiosk at once. On that fleet: **8 whole-fleet reconnect storms in 76 minutes**, of which 16 of 20 recomputes were registry churn and exactly **1** was someone editing a dashboard.

## Tests

**75 → 89**, 0 fail, and all 75 pre-existing tests pass unchanged with the option off.

Each of the three non-obvious behaviours was verified by **disarming it** and confirming the right tests fail:

| disarmed | tests that failed |
|---|---|
| hold treated as a filter, not a barrier | the reordering test, only |
| reconnect recycles every scope | the locality test, only |
| scope selection always returns the union | 4 tests, incl. the discrimination test |

That last row matters most: because every fallback lands on the union, **a scope that silently never applies looks exactly like success**. The only thing that separates them is a test asserting a connection does *not* see another dashboard's entities.

## Validation in production

Running on a **49-panel fleet** since this was written:

- entities per panel **min 138 / p50 146 / max 178**, down from 535 — 0 panels over 200, 0 still on the union, 0 rendering `unavailable`
- DOM within **0.92 %** of the unscoped baseline across four hardware variants
- **49 distinct users scoped, 0 connections fell back**
- user lookup costs **+2.9 ms** to `get_states` and nothing to auth (it overlaps the browser's own auth round trip); resolution is cached per token for 10 min
- heartbeat continuity after cutover: 200 gaps, median 292 s against a 300 s beat, worst 300 s

## One caveat worth stating

Per-connection scoping makes a **pre-existing, invisible misconfiguration visible**: a kiosk signed in as the *wrong* HA account renders perfectly under a union and breaks under scoping, because it's handed a different dashboard's allowlist. That happened once during rollout. It's arguably the option surfacing a real fault, but it's worth knowing before you enable it on a fleet.
